### PR TITLE
Added one more and updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,10 @@ Additional functions:
  
   An experimental LKM rootkit for v4.x/5.x kernels which opens a backdoor that can be used to get a reverse shell remotely.
 
+- https://github.com/reveng007/reveng_rtkit
+
+  Linux Loadable Kernel Module (LKM) based rootkit capable of hiding itself, processes/implants, rmmod proof, has ability to bypass infamous rkhunter antirootkit.
+
 ## :speak_no_evil: related stuff
 
 - https://github.com/landhb/DrawBridge
@@ -197,9 +201,9 @@ Additional functions:
 
   LKM (loadable kernel module) that makes userland processes unkillable.
 
-- https://github.com/reveng007/reveng_rtkit
+- https://web.archive.org/web/20140701183221/https://www.thc.org/papers/LKM_HACKING.html
 
-  Linux Loadable Kernel Module (LKM) based rootkit capable of hiding itself, processes/implants, rmmod proof, has ability to bypass infamous rkhunter antirootkit.
+  Heroin, any more LKM rootkit techniques.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Additional functions:
 
 - https://web.archive.org/web/20140701183221/https://www.thc.org/papers/LKM_HACKING.html
 
-  Heroin, any more LKM rootkit techniques.
+  Heroin, an LKM based rootkit, and many more LKM based rootkit techniques (it's backdated, but posses powerful knowledge).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,10 @@ Additional functions:
 
   LKM (loadable kernel module) that makes userland processes unkillable.
 
+- https://github.com/reveng007/reveng_rtkit
+
+  Linux Loadable Kernel Module (LKM) based rootkit capable of hiding itself, processes/implants, rmmod proof, has ability to bypass infamous rkhunter antirootkit.
+
 ## Contributing
 
 [Please refer the guidelines at contributing.md for details](CONTRIBUTING.md)


### PR DESCRIPTION
Removed reveng_rtkit from ***related stuff*** section and added it under ***:hear_no_evil: kernel mode rootkits*** section, as it is actually a LKM based rootkit, not related stuff, my bad!, I should have done this previously 🥲.
Apart from that, added another link to ***:speak_no_evil: related stuff*** section,  where I came across all concepts of LKM based rootkit, right from basics. The only drawback is, it is very much backdated but that webpage is full of powerful LKM based knowledge.