### PR TITLE
Adding TripleCross eBPF rootkit to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,10 @@ Additional functions:
 - https://github.com/milabs/kopycat
 
   KOPYCAT - Linux Kernel module-less implant (backdoor).
+  
+- https://github.com/h3xduck/TripleCross
+ 
+  A Linux eBPF rootkit with a backdoor, C2, library injection, execution hijacking, persistence and stealth capabilities.
 
 ## :speak_no_evil: related stuff
 


### PR DESCRIPTION
We have created a Linux eBPF rootkit named TripleCross and we would like to have it on the list 