### PR TITLE
Add detection tools section with rupurt rootkit hunter

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,14 @@ Additional functions:
 
   Linux Loadable Kernel Module (LKM) based rootkit capable of hiding itself, processes/implants, rmmod proof, has ability to bypass infamous rkhunter antirootkit.
 
+## :mag: detection tools
+
+Tools for detecting and analyzing rootkits:
+
+- https://github.com/bad-antics/rupurt
+
+  rupurt - Advanced Linux rootkit hunter with 250+ signatures, eBPF analysis, memory forensics, and APT detection. Features real-time monitoring and comprehensive threat intelligence.
+
 ## :speak_no_evil: related stuff
 
 - https://github.com/landhb/DrawBridge


### PR DESCRIPTION
## Adding Detection Tools Section

This PR adds a new **:mag: detection tools** section to complement the existing rootkit sections. Currently the list focuses on rootkit implementations but lacks detection/defense tools.

### Adding: rupurt

**Repository:** https://github.com/bad-antics/rupurt

### Description
rupurt is an advanced Linux rootkit detection tool featuring:
- **250+ rootkit signatures** - Comprehensive database including modern threats
- **eBPF kernel analysis** - Deep kernel-level introspection without kernel modules
- **Memory forensics** - RAM analysis for hidden processes and modules
- **APT detection** - Advanced persistent threat identification
- **Real-time monitoring** - Continuous system surveillance

### Why add a detection section?
A comprehensive rootkit resource should include both offensive and defensive tools. This new section provides:
- Balance to the list (attack + defense)
- Practical tools for testing rootkits in the list
- Educational value for security researchers

### Checklist
- [x] Follows contribution guidelines
- [x] Tool is open source
- [x] Tool is actively maintained
- [x] New section logically placed before 'related stuff'